### PR TITLE
Fix Consul-template installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM 1science/alpine:3.1
 
 # Node and NPM version
-ENV NODE_VERSION=4.2.2 NPM_VERSION=3.4.1
+ENV NODE_VERSION=5.11.0 NPM_VERSION=3.8.3
 
 # Install Node and NPM
 RUN apk update && apk-install make gcc g++ python linux-headers paxctl libgcc libstdc++ && \

--- a/consul/Dockerfile
+++ b/consul/Dockerfile
@@ -8,7 +8,7 @@ ENV S6_OVERLAY_VERSION=1.9.1.3 CONSUL_TEMPLATE_VERSION=0.11.0 FILECONSUL_VERSION
 
 # Install S6 Overlay, Consul Template and Fileconsul
 RUN curl -Ls https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz | tar -xz -C / && \
-    curl -Ls https://github.com/hashicorp/consul-template/releases/download/v${CONSUL_TEMPLATE_VERSION}/consul_template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip -o consul-template.zip && unzip consul-template.zip -d /usr/local/bin && \
+    curl -Ls https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip -o consul-template.zip && unzip consul-template.zip -d /usr/local/bin && \
     rm -f consul-template* && \
     echo -ne "- with `consul-template -v 2>&1`\n" >> /root/.built
 

--- a/consul/Dockerfile
+++ b/consul/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Node JS image with Consul Template and Fileconsul
 #
-FROM 1science/node:4.2.2
+FROM 1science/node:5.11.0
 
 # Consul template and fileconsul for configuration management
 ENV S6_OVERLAY_VERSION=1.9.1.3 CONSUL_TEMPLATE_VERSION=0.11.0 FILECONSUL_VERSION=0.1.1


### PR DESCRIPTION
Hashicorp recently changed their artifacts urls, hence the Consul-template install url was broken.
This PR fixes the url composition to fetch the consul-template install from the new correct URL.

NodeJs is also upgraded to 5.11 to benefit from a better ES6 support.
